### PR TITLE
add missing build deps to CentOS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ sudo passwd makerpm
 sudo yum install rpm-build redhat-rpm-config rpmdevtools
 
 # install openresty's build requirements:
-sudo yum install openssl-devel zlib-devel pcre-devel gcc make perl perl-Data-Dumper
+sudo yum install openssl-devel zlib-devel pcre-devel gcc make perl perl-Data-Dumper libtool ElectricFence systemtap-sdt-devel
 
 # login as makerpm:
 sudo su - makerpm

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ sudo passwd makerpm
 sudo yum install rpm-build redhat-rpm-config rpmdevtools
 
 # install openresty's build requirements:
-sudo yum install openssl-devel zlib-devel pcre-devel gcc make perl perl-Data-Dumper libtool ElectricFence systemtap-sdt-devel
+sudo yum install openssl-devel zlib-devel pcre-devel gcc make perl perl-Data-Dumper libtool ElectricFence systemtap-sdt-devel valgrind-devel
 
 # login as makerpm:
 sudo su - makerpm


### PR DESCRIPTION
libtool: required by openresty-pcre and openresty-zlib
ElectricFence: required by openresty-openssl-debug
systemtap-sdt-devel: required by openresty
valgrind-devel: required by openresty-valgrind