### PR TITLE
install C++ compiler for openresty-pcre on CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ sudo passwd makerpm
 
 # install rpm build tools:
 sudo yum install rpm-build redhat-rpm-config rpmdevtools
+sudo yum install gcc-c++
 
 # install openresty's build requirements:
 sudo yum install openssl-devel zlib-devel pcre-devel gcc make perl perl-Data-Dumper


### PR DESCRIPTION
This installs a c++ compiler before trying to compile `openresty-pcre`.

```
+ ./configure --prefix=/usr/local/openresty/pcre --enable-jit --enable-utf --enable-unicode-properties
configure: error: You need a C++ compiler for C++ support.
error: Bad exit status from /var/tmp/rpm-tmp.zi0Da3 (%build)
    Bad exit status from /var/tmp/rpm-tmp.zi0Da3 (%build)
Error: Nothing to do
```