### PR TITLE
rpm:  explictly using config prefix and macro %setup  openresty.spec

### DIFF
--- a/rpm/SPECS/openresty.spec
+++ b/rpm/SPECS/openresty.spec
@@ -119,13 +119,14 @@ This package provides the client side tool, opm, for OpenResty Pakcage Manager (
 
 
 %prep
-%setup -q
+%setup -q -n "openresty-%{version}"
 
 #%patch0 -p1
 
 
 %build
 ./configure \
+    --prefix="%{orprefix}" \
     --with-cc-opt="-I%{zlib_prefix}/include -I%{pcre_prefix}/include -I%{openssl_prefix}/include" \
     --with-ld-opt="-L%{zlib_prefix}/lib -L%{pcre_prefix}/lib -L%{openssl_prefix}/lib -Wl,-rpath,%{zlib_prefix}/lib:%{pcre_prefix}/lib:%{openssl_prefix}/lib" \
     --with-pcre-jit \


### PR DESCRIPTION
Hello.
@agentzh I'm ready using the openresty superpower in my production environment:). For some reasons i have to add the rpm package for prefix like `xx-openresty` for  discriminating the package  is from upstream or rpm packaging by ourself. So if we expose these options, it's convenient for these guys who want to build rpm by themself.

Also I found that it have exposed the `config prefix` and `macro %setup `in [openresty-debug](https://github.com/openresty/openresty-packaging/blob/master/rpm/SPECS/openresty-debug.spec) and [openresty-valgrind](https://github.com/openresty/openresty-packaging/blob/master/rpm/SPECS/openresty-valgrind.spec)
 
What do you think of it:)