### PR TITLE
init script: explicity specify pidfile to status()

### DIFF
--- a/rpm/SOURCES/openresty.init
+++ b/rpm/SOURCES/openresty.init
@@ -73,7 +73,7 @@ configtest() {
 }
 
 rh_status() {
-    status $nginx
+    status -p "$pidfile" $nginx
 }
 
 rh_status_q() {


### PR DESCRIPTION
Once the pidfile option is omitted, status() will use `pidof` to check if OpenResty is running. This fallback doesn't work when we run multiple OpenResty instances(with differnt configures) in the same server.