### PR TITLE
bugfix: should add quotation marks.

### DIFF
--- a/deb/openresty/debian/openresty.init
+++ b/deb/openresty/debian/openresty.init
@@ -13,7 +13,7 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/local/openresty/nginx/sbin/nginx
 NAME=nginx
-DESC=full-fledged web platform
+DESC="full-fledged web platform"
 
 if [ -r /etc/default/openresty ]; then
         . /etc/default/openresty


### PR DESCRIPTION
Got this error message on my ubuntu now: `/etc/init.d/openresty: line 16: web: command not found`