### PR TITLE
improve systemd int conf and sysV init script

### DIFF
--- a/deb/openresty/debian/openresty.init
+++ b/deb/openresty/debian/openresty.init
@@ -11,16 +11,17 @@
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/bin/openresty
-NAME=openresty
-DESC="OpenResty (full-fledged web platform)"
+DAEMON="/usr/bin/openresty"
+NAME=$(basename ${DAEMON}) #because $DAEMON maybe /usr/bin/openresty or  /usr/local/openresty/nginx/sbin/nginx
+STR_NAME="OpenResty"
+DESC="full-fledged web platform"
 
 if [ -r /etc/default/openresty ]; then
         . /etc/default/openresty
 fi
-#Sync ths behavior as writtenE in systemd init
-OPENRESTY_PREFIX="${OPENRESTY_PREFIX:-/usr/local/openresty.app/nginx/}"
-DAEMON_OPTS=${DAEMON_OPTS} -p ${OPENRESTY_PREFIX}
+#Sync ths behavior as systemd init
+OPENRESTY_PREFIX="${OPENRESTY_PREFIX:-/usr/local/openresty/nginx/}"
+DAEMON_OPTS="${DAEMON_OPTS} -p ${OPENRESTY_PREFIX}"
 
 STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"
 
@@ -33,7 +34,7 @@ test -x $DAEMON || exit 0
 # Nevertheless, because the program won't start with config file that has errors
 PID=$(${DAEMON} ${DAEMON_OPTS} -T 2>/dev/null |sed -rn 's/^pid\s+(.*?)\;/\1/p')
 if [ -z "$PID" ]; then
-	PID=/usr/local/openresty/nginx/logs/nginx.pid
+	PID="`${DAEMON} -V  2>&1 |sed -rn 's/.*prefix=([a-zA-Z/_]+)\s.*/\1/p'`/logs/nginx.pid"
 fi
 
 start_nginx() {
@@ -51,7 +52,7 @@ start_nginx() {
 }
 
 test_config() {
-	$DAEMON -q -t -c $DAEMON_OPTS >/dev/null 2>&1
+	$DAEMON -q -t $DAEMON_OPTS >/dev/null 2>&1
 }
 
 stop_nginx() {
@@ -111,7 +112,7 @@ upgrade_nginx() {
 
 case "$1" in
 	start)
-		log_daemon_msg "Starting $DESC" "$NAME"
+		log_daemon_msg "Starting $DESC" "$STR_NAME"
 		start_nginx
 		case "$?" in
 			0|1) log_end_msg 0 ;;
@@ -119,7 +120,7 @@ case "$1" in
 		esac
 		;;
 	stop)
-		log_daemon_msg "Stopping $DESC" "$NAME"
+		log_daemon_msg "Stopping $DESC" "$STR_NAME"
 		stop_nginx
 		case "$?" in
 			0|1) log_end_msg 0 ;;
@@ -127,7 +128,7 @@ case "$1" in
 		esac
 		;;
 	restart)
-		log_daemon_msg "Restarting $DESC" "$NAME"
+		log_daemon_msg "Restarting $DESC" "$STR_NAME"
 
 		# Check configuration before stopping nginx
 		if ! test_config; then
@@ -152,7 +153,7 @@ case "$1" in
 		esac
 		;;
 	reload|force-reload)
-		log_daemon_msg "Reloading $DESC configuration" "$NAME"
+		log_daemon_msg "Reloading $DESC configuration" "$STR_NAME"
 
 		# Check configuration before stopping nginx
 		#
@@ -174,20 +175,20 @@ case "$1" in
 		log_end_msg $?
 		;;
 	status)
-		status_of_proc -p $PID "$DAEMON" "$NAME" && exit 0 || exit $?
+		status_of_proc -p $PID "$DAEMON" "$STR_NAME" && exit 0 || exit $?
 		;;
 	upgrade)
-		log_daemon_msg "Upgrading binary" "$NAME"
+		log_daemon_msg "Upgrading binary" "$STR_NAME"
 		upgrade_nginx
 		log_end_msg $?
 		;;
 	rotate)
-		log_daemon_msg "Re-opening $DESC log files" "$NAME"
+		log_daemon_msg "Re-opening $DESC log files" "$STR_NAME"
 		rotate_logs
 		log_end_msg $?
 		;;
 	*)
-		echo "Usage: $NAME {start|stop|restart|reload|force-reload|status|configtest|rotate|upgrade}" >&2
+		echo "Usage: $STR_NAME {start|stop|restart|reload|force-reload|status|configtest|rotate|upgrade}" >&2
 		exit 3
 		;;
 esac

--- a/deb/openresty/debian/openresty.init
+++ b/deb/openresty/debian/openresty.init
@@ -6,18 +6,21 @@
 # Required-Stop:     $local_fs $remote_fs $network $syslog $named
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: starts openresty
-# Description:       starts openresty using start-stop-daemon
+# Short-Description: starts OpenResty
+# Description:       starts OpenResty using start-stop-daemon
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/local/openresty/nginx/sbin/nginx
-NAME=nginx
-DESC="full-fledged web platform"
+DAEMON=/usr/bin/openresty
+NAME=openresty
+DESC="OpenResty (full-fledged web platform)"
 
 if [ -r /etc/default/openresty ]; then
         . /etc/default/openresty
 fi
+#Sync ths behavior as writtenE in systemd init
+OPENRESTY_PREFIX="${OPENRESTY_PREFIX:-/usr/local/openresty.app/nginx/}"
+DAEMON_OPTS=${DAEMON_OPTS} -p ${OPENRESTY_PREFIX}
 
 STOP_SCHEDULE="${STOP_SCHEDULE:-QUIT/5/TERM/5/KILL/5}"
 
@@ -26,7 +29,9 @@ test -x $DAEMON || exit 0
 . /lib/init/vars.sh
 . /lib/lsb/init-functions
 
-PID=$(cat /usr/local/openresty/nginx/conf/nginx.conf | grep -Ev '^\s*#' | awk 'BEGIN { RS="[;{}]" } { if ($1 == "pid") print $2 }' | head -n1)
+# If the config file has errors, pid will return empty.
+# Nevertheless, because the program won't start with config file that has errors
+PID=$(${DAEMON} ${DAEMON_OPTS} -T 2>/dev/null |sed -rn 's/^pid\s+(.*?)\;/\1/p')
 if [ -z "$PID" ]; then
 	PID=/usr/local/openresty/nginx/logs/nginx.pid
 fi

--- a/deb/openresty/debian/openresty.service
+++ b/deb/openresty/debian/openresty.service
@@ -1,27 +1,30 @@
-# Stop dance for nginx
+# Stop dance for OpenResty
 # =======================
 #
-# ExecStop sends SIGSTOP (graceful stop) to the nginx process.
-# If, after 5s (--retry QUIT/5) nginx is still running, systemd takes control
+# ExecStop sends SIGSTOP (graceful stop) to the OpenResty process.
+# If, after 5s (--retry QUIT/5) OpenResty is still running, systemd takes control
 # and sends SIGTERM (fast shutdown) to the main process.
-# After another 5s (TimeoutStopSec=5), and if nginx is alive, systemd sends
+# After another 5s (TimeoutStopSec=5), and if OpenResty is alive, systemd sends
 # SIGKILL to all the remaining processes in the process group (KillMode=mixed).
 #
 # nginx signals reference doc:
 # http://nginx.org/en/docs/control.html
 #
 [Unit]
-Description=full-fledged web platform
+Description=OpenResty (full-fledged web platform)
 After=network.target
 
 [Service]
+#This is Default Prefix build in OpenResty official repo
+Environment=OPENRESTY_PREFIX=/usr/local/openresty/nginx/
+#User can set OPENRESTY_PREFIX=/usr/local/openresty.your/nginx/ in this file to
+#avoid polluting the OpenResty installation trees under /usr/local/openresty/
+#It's a traditional of debian
+EnvironmentFile=-/etc/default/openresty
 Type=forking
-PIDFile=/usr/local/openresty/nginx/logs/nginx.pid
-ExecStartPre=/usr/local/openresty/nginx/sbin/nginx -t -q -g 'daemon on; master_process on;'
-ExecStart=/usr/local/openresty/nginx/sbin/nginx -g 'daemon on; master_process on;'
-ExecReload=/usr/local/openresty/nginx/sbin/nginx -g 'daemon on; master_process on;' -s reload
-ExecStop=-/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /usr/local/openresty/nginx/logs/nginx.pid
-TimeoutStopSec=5
+ExecStartPre=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -t -q -g 'daemon on; master_process on;'
+ExecStart=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -g 'daemon on; master_process on;'
+ExecReload=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -g 'daemon on; master_process on;' -s reload
 KillMode=mixed
 
 [Install]

--- a/deb/openresty/debian/openresty.service
+++ b/deb/openresty/debian/openresty.service
@@ -17,11 +17,8 @@ After=network.target
 [Service]
 #This is Default Prefix build in OpenResty official repo
 Environment=OPENRESTY_PREFIX=/usr/local/openresty/nginx/
-#User can set OPENRESTY_PREFIX=/usr/local/openresty.your/nginx/ in this file to
-#avoid polluting the OpenResty installation trees under /usr/local/openresty/
-#It's a traditional of debian
-EnvironmentFile=-/etc/default/openresty
-#In the world of systemd, PIDFile is not very important, $MAINPID is set to the main process of the daemon
+#User can overwrite this environment via `systemctl edit openresty` to create a override file
+#In the world of systemd, PIDFile is not very important, $MAINPID will be set to the main process of the daemon
 Type=forking
 ExecStartPre=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -t -q -g 'daemon on; master_process on;'
 ExecStart=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -g 'daemon on; master_process on;'

--- a/deb/openresty/debian/openresty.service
+++ b/deb/openresty/debian/openresty.service
@@ -1,14 +1,9 @@
 # Stop dance for OpenResty
 # =======================
 #
-# ExecStop sends SIGSTOP (graceful stop) to the OpenResty process.
-# If, after 5s (--retry QUIT/5) OpenResty is still running, systemd takes control
-# and sends SIGTERM (fast shutdown) to the main process.
-# After another 5s (TimeoutStopSec=5), and if OpenResty is alive, systemd sends
-# SIGKILL to all the remaining processes in the process group (KillMode=mixed).
-#
-# nginx signals reference doc:
-# http://nginx.org/en/docs/control.html
+# nginx systemd reference doc:
+# https://www.nginx.com/resources/wiki/start/topics/examples/systemd/
+# In the world of systemd, `PIDFile` is not very important, $MAINPID will be set to the main process of the daemon
 #
 [Unit]
 Description=OpenResty (full-fledged web platform)
@@ -18,11 +13,11 @@ After=network.target
 #This is Default Prefix build in OpenResty official repo
 Environment=OPENRESTY_PREFIX=/usr/local/openresty/nginx/
 #User can overwrite this environment via `systemctl edit openresty` to create a override file
-#In the world of systemd, PIDFile is not very important, $MAINPID will be set to the main process of the daemon
 Type=forking
 ExecStartPre=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -t -q -g 'daemon on; master_process on;'
 ExecStart=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -g 'daemon on; master_process on;'
 ExecReload=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -g 'daemon on; master_process on;' -s reload
+ExecStop=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -g 'daemon on; master_process on;' -s stop
 KillMode=mixed
 
 [Install]

--- a/deb/openresty/debian/openresty.service
+++ b/deb/openresty/debian/openresty.service
@@ -21,6 +21,7 @@ Environment=OPENRESTY_PREFIX=/usr/local/openresty/nginx/
 #avoid polluting the OpenResty installation trees under /usr/local/openresty/
 #It's a traditional of debian
 EnvironmentFile=-/etc/default/openresty
+#In the world of systemd, PIDFile is not very important, $MAINPID is set to the main process of the daemon
 Type=forking
 ExecStartPre=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -t -q -g 'daemon on; master_process on;'
 ExecStart=/usr/bin/openresty -p ${OPENRESTY_PREFIX} -g 'daemon on; master_process on;'


### PR DESCRIPTION
For sysV init script:

1. Fix a failure `test_config` directive, if you add the `-c` parameter,you  must have a  specify configuration filename
should just remove this and add a  flexible `$DAEMON_OPTS` to make it right
[the old one](https://github.com/openresty/openresty-packaging/blob/c96137db4bda426edbf39a2c6d4a1063e9228e9d/deb/openresty/debian/openresty.init#L48-L50) will always fail in debian wheezy when use sysV init by calling '/etc/init.d/openresty restart'

1. Make `$OPENRESTY_PREFIX` flexible, this var can be set via create a  `/etc/default/openresty` environment file ([`/etc/default/` in Debian is something  alike  `/etc/sysconfig` in CENTOS](http://0pointer.de/blog/projects/on-etc-sysinit.html)) , one can make a separate prefix without edit the init script, the original init script should only be maintained by deb packager, and should be rolling up among the version update .

1. Use the `/usr/bin/openresty` as exec instead of `/usr/local/openresty/nginx/sbin/nginx` 

1. Make `$PID` flexible, will [try to get `pid` via the configureation dump by `nginx -T`](https://github.com/ihipop/openresty-packaging/blob/b1cb70feea524735c4ffb6a0db5801b83a79cc5d/deb/openresty/debian/openresty.init#L35) ,if empty,
use [the default `pid` PATH prefix report by `nginx -V`](https://github.com/ihipop/openresty-packaging/blob/b1cb70feea524735c4ffb6a0db5801b83a79cc5d/deb/openresty/debian/openresty.init#L37)

1. Change any description from `nginx` to `OpenResty`, fix some command to still print `nginx` prefix,such as `/etc/init.d/openresty status`, which will cause confusion with the default nginx service


For systemd init config file:

1. `PIDFile` should not set to a fixed one, in the world of systemd, PIDFile is not very important, `$MAINPID` will be set to the main process of the daemon ([Reference](https://www.nginx.com/resources/wiki/start/topics/examples/systemd/))， if `PIDFile` is fixed ,every time user change their configuration in nginx config, they have to change the `PIDFile`  in systemd config.

1. Make `$OPENRESTY_PREFIX` flexible via systemd `Environment` one can  overwrite this environment via `systemctl edit openresty` to create a override file, **without editing** the `/lib/systemd/system/openresty.service` , the original init config should only be maintained by deb packager, and should be rolling up among the version update .
for example 
![image](https://user-images.githubusercontent.com/423077/27027187-fd21dd6a-4f92-11e7-98ac-adcf3a5fbe00.png)
![image](https://user-images.githubusercontent.com/423077/27025793-4eac5b9c-4f8e-11e7-930d-b88fe2806225.png)


1. Use the `/usr/bin/openresty` as exec instead of `/usr/local/openresty/nginx/sbin/nginx` 

1. Change any description from `nginx` to `OpenResty`


![image](https://user-images.githubusercontent.com/423077/27062870-c0881e62-5020-11e7-9760-e32a1a8787dc.png)

