### PR TITLE
test_config should not have -c option

### DIFF
--- a/deb/openresty/debian/openresty.init
+++ b/deb/openresty/debian/openresty.init
@@ -46,7 +46,7 @@ start_nginx() {
 }
 
 test_config() {
-	$DAEMON -q -t -c $DAEMON_OPTS >/dev/null 2>&1
+	$DAEMON -q -t $DAEMON_OPTS >/dev/null 2>&1
 }
 
 stop_nginx() {


### PR DESCRIPTION
Not sure why the `-c` option is present when `$DAEMON_OPTS` doesn't refer to the path to the config file.