### PR TITLE
Adding image filter, xslt filter, and geo ip as dynamic modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Ubuntu/Debian
 For Ubuntu 14.04+ and Debian 7.x+:
 
 ```bash
-sudo apt-get install libtemplate-perl dh-systemd systemtap-sdt-dev perl gnupg curl make build-essential dh-make bzr-builddeb
+sudo apt-get install libtemplate-perl dh-systemd systemtap-sdt-dev perl gnupg curl make build-essential dh-make bzr-builddeb libgd-dev libgeoip-dev libxslt1-dev
 
 cd /path/to/openresty-packaging/deb/
 make zlib-build

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ sudo passwd makerpm
 sudo dnf install @development-tools fedora-packager rpmdevtools
 
 # install openresty's build requirements:
-sudo dnf install openssl-devel zlib-devel pcre-devel gcc make perl perl-Data-Dumper
+sudo dnf install openssl-devel zlib-devel pcre-devel gcc make perl \
+    perl-Data-Dumper gd-devel libxslt-devel GeoIP-devel
 
 # login as makerpm:
 sudo su - makerpm
@@ -94,7 +95,8 @@ sudo yum install rpm-build redhat-rpm-config rpmdevtools
 
 # install openresty's build requirements:
 sudo yum install openssl-devel zlib-devel pcre-devel gcc make perl \
-    perl-Data-Dumper libtool ElectricFence systemtap-sdt-devel valgrind-devel
+    perl-Data-Dumper libtool ElectricFence systemtap-sdt-devel valgrind-devel \
+    gd-devel libxslt-devel GeoIP-devel
 
 # login as makerpm:
 sudo su - makerpm
@@ -206,4 +208,3 @@ See Also
 * [OpenResty official site](https://openresty.org/)
 
 [Back to TOC](#table-of-contents)
-

--- a/deb/openresty/debian/openresty.install
+++ b/deb/openresty/debian/openresty.install
@@ -3,6 +3,7 @@ usr/local/openresty/site/lualib
 usr/local/openresty/luajit/*
 usr/local/openresty/lualib/*
 usr/local/openresty/nginx/html/*
+usr/local/openresty/nginx/modules/*
 usr/local/openresty/nginx/sbin/*
 usr/local/openresty/nginx/tapset/*
 usr/local/openresty/nginx/conf/*

--- a/deb/openresty/debian/rules
+++ b/deb/openresty/debian/rules
@@ -41,6 +41,9 @@ override_dh_auto_configure:
 	  --with-threads \
 	  --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
 	  --with-dtrace-probes \
+	  --with-http_image_filter_module=dynamic \
+	  --with-http_geoip_module=dynamic \
+	  --with-http_xslt_module=dynamic \
 	  -j$(NJBS)
 
 override_dh_usrlocal:

--- a/rpm/SPECS/openresty.spec
+++ b/rpm/SPECS/openresty.spec
@@ -174,6 +174,9 @@ This package provides the client side tool, opm, for OpenResty Pakcage Manager (
     --with-threads \
     --with-luajit-xcflags='-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT' \
     --with-dtrace-probes \
+    --with-http_image_filter_module=dynamic \
+    --with-http_geoip_module=dynamic \
+    --with-http_xslt_module=dynamic \
     %{?_smp_mflags}
 
 make %{?_smp_mflags}
@@ -225,6 +228,7 @@ fi
 %{orprefix}/lualib/*
 %{orprefix}/nginx/html/*
 %{orprefix}/nginx/logs/
+%{orprefix}/nginx/modules/*
 %{orprefix}/nginx/sbin/*
 %{orprefix}/nginx/tapset/*
 %config(noreplace) %{orprefix}/nginx/conf/*
@@ -260,6 +264,8 @@ fi
 
 
 %changelog
+* Sun Jun 03 2018 Ed Whitehead (edrw-bt) 1.13.6.2-2
+- added image filter, xslt filter, and geo ip modules as dynamic nginx modules
 * Mon May 14 2018 Yichun Zhang (agentzh) 1.13.6.2-1
 - upgraded openresty to 1.13.6.2.
 * Sun Nov 12 2017 Yichun Zhang (agentzh) 1.13.6.1-1


### PR DESCRIPTION
Tested builds on the vagrant boxes edrw/centos7-64 and ubuntu/trusty64.

I updated the rpm changelog to include a note about the update. I assumed this would be version `1.13.6.2-2` of the package. Did not update the deb changelog since I saw debuild asks for the key of the user who last edited the changelog so I figure that should be OpenResty Admin.

Encountered an issue with debuild trying to sign the package after building it and blowing up because the secret key was not available. I added the args `-uc -us` to the debuild command to prevent it from attempting to sign the package. Noticed that currently the package is signed in a separate step that is kept commented out. Would you like me to add that change to the branch or submit a separate PR so deb builds will work for other contributors without having to edit the Makefile?

This is my first time messing with packaging, let me know if you see any issues that need to be addressed.