### PR TITLE
systemd: start openresty after syslog.target network-online.target remote-fs.target nss-lookup.target

### DIFF
--- a/deb/openresty/debian/openresty.service
+++ b/deb/openresty/debian/openresty.service
@@ -13,6 +13,7 @@
 [Unit]
 Description=full-fledged web platform
 After=syslog.target network-online.target remote-fs.target nss-lookup.target
+Wants=network-online.target
 
 [Service]
 Type=forking

--- a/deb/openresty/debian/openresty.service
+++ b/deb/openresty/debian/openresty.service
@@ -12,7 +12,7 @@
 #
 [Unit]
 Description=full-fledged web platform
-After=network.target
+After=syslog.target network-online.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking

--- a/rpm/SOURCES/openresty.service
+++ b/rpm/SOURCES/openresty.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=The OpenResty Application Platform
-After=syslog.target network.target remote-fs.target nss-lookup.target
+After=syslog.target network-online.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=forking

--- a/rpm/SOURCES/openresty.service
+++ b/rpm/SOURCES/openresty.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=The OpenResty Application Platform
 After=syslog.target network-online.target remote-fs.target nss-lookup.target
+Wants=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
If the OpenResty config requires a remote filesystem or functioning DNS resolution it will sometimes fail to start without this change.

Fixes https://github.com/openresty/openresty/issues/590

cc: @doujiang24 