### PR TITLE
add BuildRequires:  perl-generators 

### DIFF
--- a/rpm/SPECS/perl-Readonly.spec
+++ b/rpm/SPECS/perl-Readonly.spec
@@ -11,6 +11,7 @@ BuildArch:      noarch
 BuildRequires:  perl >= 0:5.005
 BuildRequires:  perl(Module::Build::Tiny)
 BuildRequires:  perl(Test::More)
+BuildRequires:  perl-generators
 Requires:       perl(:MODULE_COMPAT_%(eval "`%{__perl} -V:version`"; echo $version))
 
 %description

--- a/rpm/SPECS/perl-Test-LongString.spec
+++ b/rpm/SPECS/perl-Test-LongString.spec
@@ -12,6 +12,7 @@ BuildRequires:  perl >= 1:5.8.1
 BuildRequires:  perl(ExtUtils::MakeMaker)
 BuildRequires:  perl(Test::Builder)
 BuildRequires:  perl(Test::Builder::Tester)
+BuildRequires:  perl-generators
 Requires:       perl(Test::Builder)
 Requires:       perl(Test::Builder::Tester)
 

--- a/rpm/SPECS/perl-Test-Simple.spec
+++ b/rpm/SPECS/perl-Test-Simple.spec
@@ -15,6 +15,7 @@ BuildRequires:  perl(File::Temp)
 BuildRequires:  perl(Scalar::Util) >= 1.13
 BuildRequires:  perl(Storable)
 BuildRequires:  perl(utf8)
+BuildRequires:  perl-generators
 Requires:       perl(File::Spec)
 Requires:       perl(File::Temp)
 Requires:       perl(Scalar::Util) >= 1.13


### PR DESCRIPTION
When I  build pakcages on a minimal Centos8 ,I built it successfully， but the built package lacks some providers
``` shell
# rpm -qp --provides perl-Test-LongString-0.17-1.el8.noarch.rpm
perl-Test-LongString = 0.17-1.el8
```
It made me unable to build perl-Test-Nginx because I dont have any package can provided `perl(Test::LongString)` on my local repo.

The same problems at perl-Readonly and perl-Test-Simple.

So I add ` BuildRequires:  perl-generators ` at perl-Readonly.spec perl-Test-LongString.spec perl-Test-Simple.spec .

and then 
```shell
# rpm -qp --provides perl-Test-LongString-0.17-1.el8.noarch.rpm
perl(Test::LongString) = 0.17
perl-Test-LongString = 0.17-1.el8
```
it's works~

Of course, it can be solved like [commit b6b0c78a](https://github.com/Fuchange/openresty-packaging/commit/b6b0c78a8f1c78d1b83479dd9e31995e12da372b), depending on your opinion～ 