### PR TITLE
change: rpm: openresty-asan: use -fsanitize=address instead of -lasan.

### DIFF
--- a/rpm/SPECS/openresty-asan.spec
+++ b/rpm/SPECS/openresty-asan.spec
@@ -98,7 +98,7 @@ export ASAN_OPTIONS=detect_leaks=0
 ./configure \
     --prefix="%{orprefix}" \
     --with-debug \
-    --with-cc="ccache gcc -lasan" \
+    --with-cc="ccache gcc -fsanitize=address" \
     --with-cc-opt="-I%{zlib_prefix}/include -I%{pcre_prefix}/include -I%{openssl_prefix}/include -O1" \
     --with-ld-opt="-L%{zlib_prefix}/lib -L%{pcre_prefix}/lib -L%{openssl_prefix}/lib -Wl,-rpath,%{zlib_prefix}/lib:%{pcre_prefix}/lib:%{openssl_prefix}/lib" \
     --with-pcre-jit \


### PR DESCRIPTION
The original answer -lasan is outdated and should not be used.
    See https://groups.google.com/g/address-sanitizer/c/SD590XDinfQ/m/NMUPj_G0BgAJ?pli=1 for detail.
