### PR TITLE
bugfix: failed to build on fedora 36.

### DIFF
--- a/rpm/SPECS/openresty-pcre-asan.spec
+++ b/rpm/SPECS/openresty-pcre-asan.spec
@@ -72,7 +72,7 @@ This is the gcc AddressSanitizer version.
 
 %build
 export CC="ccache gcc -fsanitize=address"
-export CFLAGS="-O1 -fno-omit-frame-pointer -g"
+export CFLAGS="-fPIC -fPIE -O1 -fno-omit-frame-pointer -g"
 export ASAN_OPTIONS=detect_leaks=0
 
 ./configure \

--- a/rpm/SPECS/openresty-pcre-asan.spec
+++ b/rpm/SPECS/openresty-pcre-asan.spec
@@ -1,6 +1,6 @@
 Name:               openresty-pcre-asan
 Version:            8.45
-Release:            1%{?dist}
+Release:            2%{?dist}
 Summary:            Clang AddressSanitizer version of the Perl-compatible regular expression library for OpenResty
 
 Group:              System Environment/Libraries


### PR DESCRIPTION
/usr/bin/ld: /tmp/ccol0vIz.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE