### PR TITLE
Don't double-background the daemon on Alpine

### DIFF
--- a/alpine/openresty-debug/openresty-debug.initd
+++ b/alpine/openresty-debug/openresty-debug.initd
@@ -9,7 +9,6 @@ extra_started_commands="reload reopen upgrade"
 name=openresty-debug
 
 command="/usr/local/$name/bin/openresty" command_args="-c $cfgfile -p $app_prefix/"
-command_background="yes"
 required_files="$cfgfile"
 
 start_stop_daemon_args=""

--- a/alpine/openresty/openresty.initd
+++ b/alpine/openresty/openresty.initd
@@ -9,7 +9,6 @@ extra_started_commands="reload reopen upgrade"
 name=openresty
 
 command="/usr/local/$name/bin/$name" command_args="-c $cfgfile -p $app_prefix/"
-command_background="yes"
 required_files="$cfgfile"
 
 start_stop_daemon_args=""


### PR DESCRIPTION
OpenResty already backgrounds itself, so asking openrc to also background it (using the same pidfile location) causes a race condition that sometimes can lead to failure.

```console
# ps -ef | grep openresty
 1122 root      0:00 grep openresty

# cat /usr/local/openresty/nginx/logs/nginx.pid
cat: can't open '/usr/local/openresty/nginx/logs/nginx.pid': No such file or directory

# start-stop-daemon --start --exec /usr/local/openresty/bin/openresty --pidfile /usr/local/openresty/nginx/logs/nginx.pid --background --make-pidfile --verbose -- -c /usr/local/openresty/nginx/conf/nginx.conf -p /usr/local/openresty/nginx
/
 * start-stop-daemon: fopen `/usr/local/openresty/nginx/logs/nginx.pid': No such file or directory
 * Detaching to start `/usr/local/openresty/bin/openresty' ...
 *   start-stop-daemon: /usr/local/openresty/bin/openresty died

# cat /usr/local/openresty/nginx/logs/nginx.pid
1126

# ps -ef | grep openresty
 1126 root      0:00 {openresty} nginx: master process /usr/local/openresty/bin/openresty -c /usr/local/openresty/nginx/conf/nginx.conf -p /usr/local/openresty/nginx/
 1127 nobody    0:00 {openresty} nginx: worker process
 1128 nobody    0:00 {openresty} nginx: worker process
 1129 nobody    0:00 {openresty} nginx: worker process
 1130 nobody    0:00 {openresty} nginx: worker process
 1133 root      0:00 grep openresty
```

Using `command_background="yes"` adds the `--background` and `--make-pidfile` options to `start-stop-daemon`. It will spawn a background process, which writes its own pid into the pidfile (`1125` in the example above).

That detached process will then exec `openresty`. But openresty will spawn yet another background process (`1126`) and exit. If `start-stop-daemon` manages to read the pidfile before it is overwritten with the final pid, it will notice that its own child process (`1125`) has terminated ("died"), and therefore reports the service as "stopped".

So openresty is actually running and the pidfile now points to the right process, but openrc is confused about it and still thinks it is stopped.

This is a race condition, and I've only observed it under specific configuration in a VM; I don't know how to reproduce it in general.

Note that `nginx` doesn't use `command_background="yes"` either: https://github.com/alpinelinux/aports/blob/master/main/nginx/nginx.initd
