### PR TITLE
Do not stop openresty service on debian package upgrade

### DIFF
--- a/deb/openresty/debian/rules
+++ b/deb/openresty/debian/rules
@@ -54,3 +54,6 @@ override_dh_auto_install:
 
 override_dh_strip:
 	dh_strip --dbg-package=openresty-dbgsym
+
+override_dh_installinit:
+	dh_installinit --no-stop-on-upgrade


### PR DESCRIPTION
When upgrading the openresty debian package, the openresty service is automatically stopped during the unpacking step, and restarted again during the setup step. This results in an unnecessary downtime.

This PR changes the dh_installinit options to prevent the service from being stopped and even restarted at all during package upgrade.

Possible evolution: I don't know how, but the ideal solution would be to use the online upgrade mechanism after the package upgrade.

Fixes #117