### PR TITLE
systemd units: specify RuntimeDirectory

### DIFF
--- a/deb/openresty/debian/openresty.service
+++ b/deb/openresty/debian/openresty.service
@@ -22,6 +22,7 @@ ExecStartPre=/usr/local/openresty/nginx/sbin/nginx -t -q -g 'daemon on; master_p
 ExecStart=/usr/local/openresty/nginx/sbin/nginx -g 'daemon on; master_process on;'
 ExecReload=/usr/local/openresty/nginx/sbin/nginx -g 'daemon on; master_process on;' -s reload
 ExecStop=-/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /usr/local/openresty/nginx/logs/nginx.pid
+RuntimeDirectory=openresty
 TimeoutStopSec=5
 KillMode=mixed
 

--- a/rpm/SOURCES/openresty.service
+++ b/rpm/SOURCES/openresty.service
@@ -10,6 +10,7 @@ ExecStartPre=/usr/local/openresty/nginx/sbin/nginx -t
 ExecStart=/usr/local/openresty/nginx/sbin/nginx
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s QUIT $MAINPID
+RuntimeDirectory=openresty
 PrivateTmp=true
 
 [Install]


### PR DESCRIPTION
The RuntimeDirectory will create /var/run/openresty folder during start of the service.

The OpenResty docker images creates the folder:
https://github.com/openresty/docker-openresty/blob/master/jammy/Dockerfile#L174

But when running from systemd the folder doesn't exists and this breaks interopability.

See also https://github.com/openresty/docker-openresty/issues/119